### PR TITLE
fix: wtmi: fix calculation of loop_ns

### DIFF
--- a/wtmi/clock.c
+++ b/wtmi/clock.c
@@ -153,7 +153,7 @@ u32 clock_init(void)
 
 	if (cm3_clk != 0) {
 		clk_ns = 1000 / cm3_clk;
-		loop_ns = clk_ns / CYCLES_PER_LOOP;
+		loop_ns = clk_ns * CYCLES_PER_LOOP;
 		status = NO_ERROR;
 	}
 


### PR DESCRIPTION
loop_ns represent nano seconds per loop. So calculation should be as follws:
  `clk_ns * CYCLES_PER_LOOP`

Because the dimension of CYCLES_PER_LOOP is `clock cycles per loop`.


Signed-off-by: Yuichi Nakai <xoxyuxu@gmail.com>