### PR TITLE
TBB: Split INCDIR from LIBDIR

### DIFF
--- a/wtptp/src/TBB_Linux/TBB_linux.mak
+++ b/wtptp/src/TBB_Linux/TBB_linux.mak
@@ -106,6 +106,7 @@ BASE_DIR_ABS	:=	$(shell pwd)
 ifeq "$(LIBDIR)" ""
 LIBDIR			+=		"$(BASE_DIR)/lib/cryptopp565"
 endif
+INCDIR			?=		$(LIBDIR)
 
 SRCDIR			+=		$(BASE_DIR)/src
 OUTDIR			=		$(BASE_DIR)/release
@@ -113,7 +114,7 @@ OUTDIR			=		$(BASE_DIR)/release
 INC_DIR_FLAGS	+=		-I$(BASE_DIR)/inc -I$(BASE_DIR)
 LIB_DIR_FLAGS	+=		-L$(LIBDIR)
 LIB_FLAGS 		+=		-lcryptopp
-DEF_FLAGS		+=		-DLIBDIR=$(LIBDIR)
+DEF_FLAGS		+=		-DINCDIR=$(INCDIR)
 CC_FLAGS 		+=		-std=c++11 --debug
 
 OBJS 			+=	$(OUTDIR)/Aspen_Strings.o \

--- a/wtptp/src/TBB_Linux/inc/CryptoPP_L_interface.h
+++ b/wtptp/src/TBB_Linux/inc/CryptoPP_L_interface.h
@@ -105,7 +105,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define __CRYPTOPP_L_INTREFACE_H__
 
 
-#define INCLUDE_FILE(fname) <LIBDIR/fname>
+#define INCLUDE_FILE(fname) <INCDIR/fname>
 
 #include INCLUDE_FILE(hex.h)
 #include INCLUDE_FILE(rsa.h)


### PR DESCRIPTION
LIBDIR is misused for the #include path. When using a distro-provided
libcryptopp, headers and libraries typically reside in different
directories. Putting the include dir into LIBDIR as a workaround fixes
the build but breaks finding libcryptopp at runtime (-L).

Therefore introduce INCDIR and default to LIBDIR if not specified.
Fixes build on openSUSE Tumbleweed with its libcryptopp.