### PR TITLE
ddr: fix typo for ESPRESSObin DDR4 2GB layout

### DIFF
--- a/tim/ddr/DDR_TOPOLOGY_6.txt
+++ b/tim/ddr/DDR_TOPOLOGY_6.txt
@@ -18,5 +18,5 @@ ddr_speedbin_index=11
 #16BIT
 ddr_bus_width_index=2
 
-#16Gbits (2GB)
-ddr_mem_size_index=5
+#8Gbits (1GB)
+ddr_mem_size_index=4


### PR DESCRIPTION
DDR4 2CS 2GB board should have 8Gbits(1GB) single chip, and current file causes boot failure.