### PR TITLE
wtmi: Fix Makefile rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,10 +17,16 @@ endif
 
 all: mv_ddr WTMI
 
-mv_ddr:
-	${Q}${MAKE} PLATFORM=a3700 --no-print-directory -C ${MV_DDR_PATH} DDR_TYPE=$(DDR_TYPE) clean
-	make -C ${MV_DDR_PATH} PLATFORM=a3700 DDR_TYPE=$(DDR_TYPE)
+$(MV_DDR_PATH)/a3700_tool: FORCE
+ifndef MV_DDR_PATH
+	$(error "'MV_DDR_PATH' is not set")
+endif
+	${Q}${MAKE} -C ${MV_DDR_PATH} PLATFORM=a3700 DDR_TYPE=$(DDR_TYPE)
+
+$(TIM_DDR_PATH)/ddr_tool: $(MV_DDR_PATH)/a3700_tool
 	@cp -f ${MV_DDR_PATH}/a3700_tool $(TIM_DDR_PATH)/ddr_tool
+
+mv_ddr: $(TIM_DDR_PATH)/ddr_tool
 
 WTMI:
 	${MAKE} -C wtmi LOCAL_VERSION_STRING=$(LOCAL_VERSION_STRING)
@@ -28,6 +34,9 @@ WTMI:
 clean:
 	${Q}${MAKE} -C wtmi clean
 	@rm -f tim/ddr/ddr_static.txt tim/ddr/clocks_ddr.txt
+ifdef MV_DDR_PATH
 	${Q}${MAKE} PLATFORM=a3700 --no-print-directory -C ${MV_DDR_PATH} DDR_TYPE=$(DDR_TYPE) clean
+endif
 
-.PHONY: all mv_ddr WTMI clean
+FORCE:;
+.PHONY: all mv_ddr WTMI clean FORCE

--- a/Makefile
+++ b/Makefile
@@ -29,3 +29,5 @@ clean:
 	${Q}${MAKE} -C wtmi clean
 	@rm -f tim/ddr/ddr_static.txt tim/ddr/clocks_ddr.txt
 	${Q}${MAKE} PLATFORM=a3700 --no-print-directory -C ${MV_DDR_PATH} DDR_TYPE=$(DDR_TYPE) clean
+
+.PHONY: all mv_ddr WTMI clean

--- a/wtmi/Makefile
+++ b/wtmi/Makefile
@@ -7,7 +7,9 @@ MKDIR    = @mkdir -p
 BINPATH		= build
 WTMI_PATH	= $(shell pwd)
 COMMON_PATH	= $(WTMI_PATH)/common
-WTMI_IMG	?= fuse/build/fuse.bin
+FUSE_IMG	:= fuse/build/fuse.bin
+WTMI_IMG	?= $(FUSE_IMG)
+WTMI_IMG_REL	:= $(shell realpath --canonicalize-missing --relative-to=$(WTMI_PATH) $(WTMI_IMG))
 SYS_INIT_IMG	:= sys_init/build/sys_init.bin
 MULTI_IMG	:= $(BINPATH)/wtmi.bin
 WTMI_PAD_IMG	:= $(BINPATH)/wtmi_app_pad.bin
@@ -39,11 +41,11 @@ $(BINPATH):
 $(SYS_INIT_IMG): $(WTMI_PAD_IMG)
 	${MAKE} -C sys_init LOAD_OFFSET=$(shell wc -c < $(WTMI_PAD_IMG)) COMMON_PATH=$(COMMON_PATH) CROSS_CM3=$(CROSS_CM3)
 
-$(WTMI_PAD_IMG): $(WTMI_IMG)
-	cp -f $(WTMI_IMG) $(WTMI_PAD_IMG)
+$(WTMI_PAD_IMG): $(WTMI_IMG_REL)
+	cp -f $(WTMI_IMG_REL) $(WTMI_PAD_IMG)
 	truncate -s %16 $(WTMI_PAD_IMG)
 
-$(WTMI_IMG):
+$(FUSE_IMG):
 	${MAKE} -C fuse COMMON_PATH=$(COMMON_PATH) CROSS_CM3=$(CROSS_CM3)
 
 clean:

--- a/wtmi/Makefile
+++ b/wtmi/Makefile
@@ -58,3 +58,4 @@ tools:
 	@$(TOOLCHAIN_CHECK)
 
 FORCE:;
+.PHONY: all clean tools FORCE

--- a/wtmi/Makefile
+++ b/wtmi/Makefile
@@ -32,20 +32,21 @@ TOOLCHAIN_CHECK = \
 		exit 1; \
 	fi
 
-all: tools $(BINPATH) $(WTMI_IMG) $(SYS_INIT_IMG)
+all: tools $(MULTI_IMG)
+
+$(MULTI_IMG): $(WTMI_PAD_IMG) $(SYS_INIT_IMG)
+	$(MKDIR) $(BINPATH)
 	cat $(WTMI_PAD_IMG) $(SYS_INIT_IMG) > $(MULTI_IMG)
 
-$(BINPATH):
-	@$(MKDIR) $(BINPATH)
-
-$(SYS_INIT_IMG): $(WTMI_PAD_IMG)
+$(SYS_INIT_IMG): $(WTMI_PAD_IMG) FORCE
 	${MAKE} -C sys_init LOAD_OFFSET=$(shell wc -c < $(WTMI_PAD_IMG)) COMMON_PATH=$(COMMON_PATH) CROSS_CM3=$(CROSS_CM3)
 
 $(WTMI_PAD_IMG): $(WTMI_IMG_REL)
+	$(MKDIR) $(BINPATH)
 	cp -f $(WTMI_IMG_REL) $(WTMI_PAD_IMG)
 	truncate -s %16 $(WTMI_PAD_IMG)
 
-$(FUSE_IMG):
+$(FUSE_IMG): FORCE
 	${MAKE} -C fuse COMMON_PATH=$(COMMON_PATH) CROSS_CM3=$(CROSS_CM3)
 
 clean:
@@ -55,3 +56,5 @@ clean:
 
 tools:
 	@$(TOOLCHAIN_CHECK)
+
+FORCE:;

--- a/wtmi/fuse/Makefile
+++ b/wtmi/fuse/Makefile
@@ -86,3 +86,5 @@ clean:
 	$(ECHO) "  CLEAN"
 	@$(RM) -rf $(BINPATH)
 	@$(RM) -f *.o $(COMMON_PATH)/*.o *.elf *.bin *dis
+
+.PHONY: all clean

--- a/wtmi/fuse/Makefile
+++ b/wtmi/fuse/Makefile
@@ -57,11 +57,18 @@ LOAD_ADDR	:= 0x1fff0000
 
 .SILENT:
 
-all: $(COBJ) $(AOBJ) $(BINPATH)
-	rm -f ./$(LDSCRIPT)
+all: $(BINPATH)/fuse.bin
+
+$(LDSCRIPT): $(COMMON_PATH)/template.ld
 	$(SED) 's|. = LOAD_ADDR|. = $(LOAD_ADDR)|1' $(COMMON_PATH)/template.ld > ./$(LDSCRIPT)
+
+$(BINPATH)/fuse.elf: $(LDSCRIPT) $(AOBJ)  $(COBJ)
 	$(ECHO) "  CC    $(LDFLAGS)  $(AOBJ)  $(COBJ) -o $(BINPATH)/fuse.elf"
+	$(MKDIR) $(BINPATH)
 	$(CC) $(LDFLAGS)  $(AOBJ)  $(COBJ) -o $(BINPATH)/fuse.elf
+
+$(BINPATH)/fuse.bin: $(BINPATH)/fuse.elf
+	$(MKDIR) $(BINPATH)
 	$(OBJCOPY) -S -O binary $(BINPATH)/fuse.elf $(BINPATH)/fuse.bin
 	@if [ `uname -m` = "x86_64" ]; then $(OBJDUMP) -D -S $(BINPATH)/fuse.elf > $(BINPATH)/fuse.dis; fi
 
@@ -74,9 +81,6 @@ all: $(COBJ) $(AOBJ) $(BINPATH)
 	$(AS) $(ASFLAGS) -o $@ $(subst .o,.S,$@)
 
 -include $(COBJ:.o=.d)
-
-$(BINPATH):
-	@$(MKDIR) $(BINPATH)
 
 clean:
 	$(ECHO) "  CLEAN"

--- a/wtmi/sys_init/Makefile
+++ b/wtmi/sys_init/Makefile
@@ -132,7 +132,6 @@ define filechk_autoconf.h
 endef
 
 .SILENT:
-.PHONY: $(CFG_HEADER)
 
 all: $(CFG_HEADER) $(COBJ) $(AOBJ) $(BINPATH)
 	rm -f ./$(LDSCRIPT)
@@ -142,7 +141,7 @@ all: $(CFG_HEADER) $(COBJ) $(AOBJ) $(BINPATH)
 	$(OBJCOPY) -S -O binary $(BINPATH)/sys_init.elf $(BINPATH)/sys_init.bin
 	@if [ `uname -m` = "x86_64" ]; then $(OBJDUMP) -D -S $(BINPATH)/sys_init.elf > $(BINPATH)/sys_init.dis; fi
 
-$(CFG_HEADER):
+$(CFG_HEADER): FORCE
 	$(call filechk,autoconf.h)
 
 %.o: %.c $(CFG_HEADER)
@@ -162,3 +161,5 @@ clean:
 	$(ECHO) "  SYS INIT CLEAN"
 	@$(RM) -rf $(BINPATH)
 	@$(RM) -f $(CFG_HEADER) *.o *.elf *.bin *.d *dis ddr/*.o ddr/*.d $(COMMON_PATH)/*.o $(LDSCRIPT)
+
+FORCE:;

--- a/wtmi/sys_init/Makefile
+++ b/wtmi/sys_init/Makefile
@@ -123,6 +123,7 @@ CONFIG_DEV_CAP   := $(shell $(GET_DDR_PARAMS) $(DDR_TOPOLOGY_FILE) ddr_mem_size_
 
 define filechk_autoconf.h
 	(echo \#define DEBUG $(DEBUG);\
+	echo \#define LOAD_ADDR $(LOAD_ADDR);\
 	echo \#define WTMI_CLOCK $(WTMI_CLOCK);\
 	echo \#define CONFIG_DDR_TYPE $(CONFIG_DDR_TYPE);\
 	echo \#define CONFIG_BUS_WIDTH $(CONFIG_BUS_WIDTH);\
@@ -133,11 +134,18 @@ endef
 
 .SILENT:
 
-all: $(CFG_HEADER) $(COBJ) $(AOBJ) $(BINPATH)
-	rm -f ./$(LDSCRIPT)
+all: $(BINPATH)/sys_init.bin
+
+$(LDSCRIPT): $(COMMON_PATH)/template.ld $(CFG_HEADER)
 	$(SED) 's|. = LOAD_ADDR|. = $(LOAD_ADDR)|1' $(COMMON_PATH)/template.ld > ./$(LDSCRIPT)
+
+$(BINPATH)/sys_init.elf: $(LDSCRIPT) $(AOBJ) $(COBJ)
 	$(ECHO) "  CC    $(LDFLAGS)  $(AOBJ)  $(COBJ) -o $(BINPATH)/sys_init.elf"
+	$(MKDIR) $(BINPATH)
 	$(CC) $(LDFLAGS)  $(AOBJ)  $(COBJ) -o $(BINPATH)/sys_init.elf
+
+$(BINPATH)/sys_init.bin: $(BINPATH)/sys_init.elf
+	$(MKDIR) $(BINPATH)
 	$(OBJCOPY) -S -O binary $(BINPATH)/sys_init.elf $(BINPATH)/sys_init.bin
 	@if [ `uname -m` = "x86_64" ]; then $(OBJDUMP) -D -S $(BINPATH)/sys_init.elf > $(BINPATH)/sys_init.dis; fi
 
@@ -153,9 +161,6 @@ $(CFG_HEADER): FORCE
 	$(AS) $(ASFLAGS) -o $@ $(subst .o,.S,$@)
 
 -include $(COBJ:.o=.d)
-
-$(BINPATH):
-	@$(MKDIR) $(BINPATH)
 
 clean:
 	$(ECHO) "  SYS INIT CLEAN"

--- a/wtmi/sys_init/Makefile
+++ b/wtmi/sys_init/Makefile
@@ -168,3 +168,4 @@ clean:
 	@$(RM) -f $(CFG_HEADER) *.o *.elf *.bin *.d *dis ddr/*.o ddr/*.d $(COMMON_PATH)/*.o $(LDSCRIPT)
 
 FORCE:;
+.PHONY: all clean FORCE

--- a/wtmi/sys_init/Makefile
+++ b/wtmi/sys_init/Makefile
@@ -94,15 +94,15 @@ LOAD_ADDR		:= $(shell printf 0x%x $(LOAD_ADDR_DEC))
 CFG_HEADER = autoconf.h
 
 define filechk
-	@set -e;				\
-	echo '  CHK     $@';		\
-	mkdir -p $(dir $@);			\
-	$(filechk_$(1)) > $@.tmp;		\
-	if [ -r $@ ] && cmp -s $@ $@.tmp; then	\
-		rm -f $@.tmp;			\
+	set -e;				\
+	echo '  CHK     $(1)';		\
+	mkdir -p $(dir $(1));			\
+	$(filechk_$(1)) > $(1).tmp;		\
+	if [ -r $(1) ] && cmp -s $(1) $(1).tmp; then	\
+		rm -f $(1).tmp;			\
 	else					\
-		echo '  UPD     $@';	\
-		mv -f $@.tmp $@;		\
+		echo '  UPD     $(1)';	\
+		mv -f $(1).tmp $(1);		\
 	fi
 endef
 


### PR DESCRIPTION
Fix dependences, add .PHONY and FORCE targets to rebuild only targets which dependences were changed.