### PR TITLE
Various changes in wtmi and tim code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,10 @@ wtmi/build/*
 *.dis
 *.bin
 #ignore specific files
+clocks_ddr.txt
 ddr_static.txt
+ddr_static.txt.info
 autoconf.h
 tim/ddr/ddr_tool
+tim/ddr/ddr_tool.verstr
 

--- a/Makefile
+++ b/Makefile
@@ -27,14 +27,17 @@ endif
 $(TIM_DDR_PATH)/ddr_tool: $(MV_DDR_PATH)/a3700_tool
 	@cp -f ${MV_DDR_PATH}/a3700_tool $(TIM_DDR_PATH)/ddr_tool
 
-mv_ddr: $(TIM_DDR_PATH)/ddr_tool
+$(TIM_DDR_PATH)/ddr_tool.verstr: $(MV_DDR_PATH)/a3700_tool
+	@echo mv_ddr-$(shell sed 's/^mv_ddr-//' $(MV_DDR_PATH)/localversion 2>/dev/null || echo 'unknown')$(if $(shell git -C $(MV_DDR_PATH) rev-parse --git-dir 2>/dev/null),-g$(shell git -C $(MV_DDR_PATH) rev-parse --verify --quiet --short HEAD 2>/dev/null)$(shell git -C $(MV_DDR_PATH) diff-index --quiet HEAD || echo -d)) > $@
+
+mv_ddr: $(TIM_DDR_PATH)/ddr_tool $(TIM_DDR_PATH)/ddr_tool.verstr
 
 WTMI:
 	${MAKE} -C wtmi LOCAL_VERSION_STRING=$(LOCAL_VERSION_STRING)
 
 clean:
 	${Q}${MAKE} -C wtmi clean
-	@rm -f tim/ddr/ddr_static.txt tim/ddr/clocks_ddr.txt
+	@rm -f tim/ddr/ddr_static.txt tim/ddr/clocks_ddr.txt tim/ddr/ddr_tool tim/ddr/ddr_tool.verstr tim/ddr/ddr_static.txt.info
 ifdef MV_DDR_PATH
 	${Q}${MAKE} PLATFORM=a3700 --no-print-directory -C ${MV_DDR_PATH} DDR_TYPE=$(DDR_TYPE) clean
 endif

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ SCRIPT_PATH		:= $(ROOT_PATH)/script
 
 DDR_TOPOLOGY		?= 0
 DDR_TOPOLOGY_FILE 	:= $(TIM_DDR_PATH)/DDR_TOPOLOGY_$(DDR_TOPOLOGY).txt
+$(if $(wildcard $(DDR_TOPOLOGY_FILE)),,$(error "DDR_TOPOLOGY=$(DDR_TOPOLOGY) is invalid"))
 GET_DDR_PARAMS=$(SCRIPT_PATH)/getddrparams.sh
 CONFIG_DDR_TYPE=$(shell ($(GET_DDR_PARAMS) $(DDR_TOPOLOGY_FILE) ddr_type))
 

--- a/script/buildtim.sh
+++ b/script/buildtim.sh
@@ -244,18 +244,18 @@ CLOCKSFILE=$CLOCKSPATH/clocks_ddr.txt
 # All DDR use the configuration for 800M
 DDRTYPE=`$GETDDRPARAMS $DDRTOPFILE ddr_type`
 
-$CLOCKSPATH/ddr_tool -i $DDRTOPFILE -o $CLOCKSPATH/ddr_static.txt
+$CLOCKSPATH/ddr_tool -i $DDRTOPFILE -o $DDRFILE
 
 if [ $? -ne 0 ]; then
 	echo "DDR_tool fails to run!"
 	exit 1
 fi
 
-if [ ! -e $CLOCKSPATH/ddr_static.txt ]; then
-	echo "Cannot find ddr_static.txt file!"
+if [ ! -e $DDRFILE ]; then
+	echo "Cannot find $DDRFILE file!"
 	exit 1
-elif [ ! -s $CLOCKSPATH/ddr_static.txt ]; then
-	echo "ddr_static.txt file is empty!"
+elif [ ! -s $DDRFILE ]; then
+	echo "$DDRFILE file is empty!"
 	exit 1
 fi
 

--- a/script/gettimver.sh
+++ b/script/gettimver.sh
@@ -34,6 +34,7 @@ fi
 VERSTR=$(cat $VERFILE)
 VERLEN=${#VERSTR}
 
+echo "WAIT_FOR_BIT_SET: 0xC001200C 0x20 1 ; Wait for TX ready" >> $OUTFILE
 echo "WRITE: 0xC0012004 0x54              ; Print 'T'" >> $OUTFILE
 echo "WAIT_FOR_BIT_SET: 0xC001200C 0x20 1 ; Wait for TX ready" >> $OUTFILE
 echo "WRITE: 0xC0012004 0x49              ; Print 'I'" >> $OUTFILE
@@ -41,19 +42,18 @@ echo "WAIT_FOR_BIT_SET: 0xC001200C 0x20 1 ; Wait for TX ready" >> $OUTFILE
 echo "WRITE: 0xC0012004 0x4D              ; Print 'M'" >> $OUTFILE
 echo "WAIT_FOR_BIT_SET: 0xC001200C 0x20 1 ; Wait for TX ready" >> $OUTFILE
 echo "WRITE: 0xC0012004 0x2D              ; Print '-'" >> $OUTFILE
-echo "WAIT_FOR_BIT_SET: 0xC001200C 0x20 1 ; Wait for TX ready" >> $OUTFILE
 
 # Print out TIM version number
 for (( i=0; i<$VERLEN; i++ ))
 do
 	CHARACTER=${VERSTR:$i:1}
 	ASCIIVAL=$(printf "%d" \'$CHARACTER)
-	echo "WRITE: 0xC0012004" $ASCIIVAL  "; Print tim version number">> $OUTFILE
 	echo "WAIT_FOR_BIT_SET: 0xC001200C 0x20 1 ; Wait for TX ready" >> $OUTFILE
+	echo "WRITE: 0xC0012004" $ASCIIVAL  "; Print tim version number">> $OUTFILE
 done
+echo "WAIT_FOR_BIT_SET: 0xC001200C 0x20 1 ; Wait for TX ready" >> $OUTFILE
 echo "WRITE: 0xC0012004 0x0D                      ; Print CR" >> $OUTFILE
 echo "WAIT_FOR_BIT_SET: 0xC001200C 0x20 1 ; Wait for TX ready" >> $OUTFILE
 echo "WRITE: 0xC0012004 0x0A                      ; Print LF" >> $OUTFILE
-echo "WAIT_FOR_BIT_SET: 0xC001200C 0x20 1 ; Wait for TX ready" >> $OUTFILE
 
 exit 0

--- a/wtmi/sys_init/Makefile
+++ b/wtmi/sys_init/Makefile
@@ -51,7 +51,7 @@ ECHO     = @echo
 SED      = @sed
 
 LOCAL_VERSION_STRING	?= -armada
-BUILD_STRING		:= $(shell git log -n 1 --pretty=format:"%h")
+BUILD_STRING		:= $(shell git log -n 1 --pretty=format:"%h" && (git diff-index --quiet HEAD || echo -dirty))
 VERSION_STRING		:= $(LOCAL_VERSION_STRING)-$(BUILD_STRING)
 
 CPUOPTS  = -mthumb -mcpu=cortex-m3 -mlittle-endian
@@ -59,7 +59,7 @@ BINPATH  = build
 LDSCRIPT = sys_init.ld
 INCLUDE  = -I. -I$(COMMON_PATH)
 
-CFLAGS   = -g -gdwarf-2 -Wall -fno-stack-protector $(INCLUDE) -Os $(CPUOPTS) -DVERSION=\"$(VERSION_STRING)\"
+CFLAGS   = -g -gdwarf-2 -Wall -fno-stack-protector $(INCLUDE) -Os $(CPUOPTS)
 CPPFLAGS =
 ASFLAGS  = -g --gdwarf-2 --warn $(INCLUDE) $(CPUOPTS)
 LDFLAGS  = -nostdlib -T $(LDSCRIPT) -Xlinker "--build-id=none"
@@ -124,6 +124,7 @@ CONFIG_DEV_CAP   := $(shell $(GET_DDR_PARAMS) $(DDR_TOPOLOGY_FILE) ddr_mem_size_
 
 define filechk_autoconf.h
 	(echo \#define DEBUG $(DEBUG);\
+	echo \#define VERSION \"$(VERSION_STRING)\";\
 	echo \#define LOAD_ADDR $(LOAD_ADDR);\
 	echo \#define WTMI_CLOCK $(WTMI_CLOCK);\
 	echo \#define CONFIG_DDR_TYPE $(CONFIG_DDR_TYPE);\

--- a/wtmi/sys_init/Makefile
+++ b/wtmi/sys_init/Makefile
@@ -111,6 +111,7 @@ endef
 # files and scripts
 DDR_TOPOLOGY_PATH=../../tim/ddr
 DDR_TOPOLOGY_FILE=$(DDR_TOPOLOGY_PATH)/DDR_TOPOLOGY_$(DDR_TOPOLOGY).txt
+$(if $(wildcard $(DDR_TOPOLOGY_FILE)),,$(error "DDR_TOPOLOGY=$(DDR_TOPOLOGY) is invalid"))
 
 SCRIPT_PATH=../../script
 GET_DDR_PARAMS=$(SCRIPT_PATH)/getddrparams.sh

--- a/wtmi/sys_init/clock.c
+++ b/wtmi/sys_init/clock.c
@@ -655,6 +655,8 @@ int setup_clock_tree(void)
 	if (preset_flag == 0)
 		return -1;
 
+	printf("Setting clocks: CPU %d MHz, DDR %d MHz\n", clk_cfg->cpu_freq_mhz, clk_cfg->ddr_freq_mhz);
+
 	/* Switch all North/South Bridge clock sources to XTAL
 	   prior to make any change to the clock configuration */
 	writel(0x00000000, MVEBU_NORTH_CLOCK_SELECT_REG);

--- a/wtmi/sys_init/uart.c
+++ b/wtmi/sys_init/uart.c
@@ -54,6 +54,12 @@ static void uart_set_baudrate(unsigned int baudrate)
 
 int uart_init(unsigned int baudrate)
 {
+	int max_wait = 3000; /* 3ms */
+
+	/* Wait 3ms for the TX (THR and TSR) to be empty */
+	while (--max_wait > 0 && !(readl(MVEBU_UART0_STATUS_REG) & BIT6))
+		wait_ns(1000);
+
 	uart_set_baudrate(baudrate);
 
 	/* reset FIFOs */

--- a/wtmi/sys_init/uart.c
+++ b/wtmi/sys_init/uart.c
@@ -77,5 +77,10 @@ void uart_putc(void *p, char c)
 
 	writel(c, MVEBU_UART0_TX_REG);
 
+	if (c == '\n') {
+		while (!(readl(MVEBU_UART0_STATUS_REG) & BIT6))
+			;
+	}
+
 	return;
 }


### PR DESCRIPTION
Changes:
* Makefile: Check that specified DDR_TOPOLOGY option is valid
* wtmi: Flush output on UART after the '\n' character
* wtmi: During setup clock phase print CPU and DDR speed
* wtmi: Add "dirty" suffix to git commit and rebuild sys_init.bin binary when VERSION changes
* wtmi: Wait 3ms for the TX on UART to be empty prior resetting TX FIFO
* tim: Fix waiting for UART TX ready
* tim: Use variable $DDRFILE where possible
* tim: Print mv_ddr version and configuration on UART

Changes are on top of the master branch.

I have test these changes on Espressobin V5 and it is working fine. During init it prints correct CPU and DDR frequencies and also correct DDR configuration and version from external mv-ddr-marvell repository.