### PR TITLE
avs: Validate VDD value from OTP

### DIFF
--- a/wtmi/sys_init/avs.c
+++ b/wtmi/sys_init/avs.c
@@ -196,12 +196,21 @@ int init_avs(u32 speed)
 	}
 
 	if (svc_rev >= SVC_REVISION_2) {
-		vdd_otp = ((otp_data[OTP_DATA_SVC_SPEED_ID] >> shift) +
-			   AVS_VDD_BASE) & AVS_VDD_MASK;
-		regval |= (vdd_otp << HIGH_VDD_LIMIT_OFF);
-		regval |= (vdd_otp << LOW_VDD_LIMIT_OFF);
-		printf("SVC REV: %d, CPU VDD voltage: %s\n", svc_rev,
-			avis_dump[vdd_otp].desc);
+		vdd_otp = (otp_data[OTP_DATA_SVC_SPEED_ID] >> shift) &
+			  AVS_VDD_MASK;
+		if (!vdd_otp || vdd_otp + AVS_VDD_BASE > AVS_VDD_MASK) {
+			regval |= (vdd_default << HIGH_VDD_LIMIT_OFF);
+			regval |= (vdd_default << LOW_VDD_LIMIT_OFF);
+			printf("SVC REV: %d, CPU VDD voltage is invalid,"
+				" using default value: %s\n", svc_rev,
+				avis_dump[vdd_default].desc);
+		} else {
+			vdd_otp += AVS_VDD_BASE;
+			regval |= (vdd_otp << HIGH_VDD_LIMIT_OFF);
+			regval |= (vdd_otp << LOW_VDD_LIMIT_OFF);
+			printf("SVC REV: %d, CPU VDD voltage: %s\n",
+				svc_rev, avis_dump[vdd_otp].desc);
+		}
 	} else {
 		regval |= (vdd_default << HIGH_VDD_LIMIT_OFF);
 		regval |= (vdd_default << LOW_VDD_LIMIT_OFF);


### PR DESCRIPTION
CPU VDD voltage value for 1.2 GHz frequency on some Espressobin boards is
not set and raw value 0x00 is returned. In this case init_avs() function
calculated CPU VDD voltage value to 0x00 + AVS_VDD_BASE = 0.898 V, which is
too low for any operation and Espressobin board immediately crashed
init_avs() function set this low value.

This patch fixes above issue by validating returned VDD value from OTP and
using default VDD value when invalid value is in OTP. With this patch
init_avs() function does cause CPU crash anymore.