### PR TITLE
sys_init: Add missing newlines in debug mode

### DIFF
--- a/wtmi/sys_init/ddr/ddrcore.c
+++ b/wtmi/sys_init/ddr/ddrcore.c
@@ -192,6 +192,7 @@ int init_ddr(struct ddr_init_para init_para,
 		self_refresh_entry(cs, tc_ddr_type);
 
 	/* 2. setup clock */
+	LogMsg(LOG_LEVEL_ERROR, FLAG_REGS_DUMP_SELFTEST, "\n\n");
 	init_para.clock_init();
 
 	/* 3. DDRPHY sync2 and DLL reset */
@@ -409,6 +410,8 @@ int init_ddr(struct ddr_init_para init_para,
 #ifdef VALIDATION_EYE
 	rx_sweep_test();
 #endif
+
+	LogMsg(LOG_LEVEL_ERROR, FLAG_REGS_DUMP_SELFTEST, "\n\n");
 	return ret_val;
 }
 #ifdef VALIDATION_EYE

--- a/wtmi/sys_init/main.c
+++ b/wtmi/sys_init/main.c
@@ -168,6 +168,7 @@ int sys_init_main(void)
 		ddr_debug("  cs[1] - bank num     %d\n", map.cs[1].bank_num);
 		ddr_debug("  cs[1] - capacity     %dMiB\n", map.cs[1].capacity);
 	}
+	ddr_debug("\n");
 
 	/* WTMI_CLOCK was set in the compile parametr */
 	set_clock_preset(WTMI_CLOCK);


### PR DESCRIPTION
WTMI sys_init code in debug mode prints some verbose lines which are not
terminated by a newline. E.g.:

    SELF-REFRESH TEST PASSSetting clocks: CPU 1200 MHz, DDR 750 MHz

    SELF-REFRESH TEST PASSNOTICE:  Booting Trusted Firmware

This change adds missing newlines to make debug log more readable.