### PR TITLE
fix: twin die ddr porting guide

### DIFF
--- a/tim/ddr/porting_guide.txt
+++ b/tim/ddr/porting_guide.txt
@@ -60,7 +60,7 @@ The configuration file is like below::
 	ddr_cas_write_latency=8
 
 	#twin-die combined
-	mv_ddr_twin_die=0
+	ddr_twin_die_index=1
 
 5. configuration items
 ----------------------
@@ -87,9 +87,9 @@ The configuration file is like below::
 	        default value: DDR3-800Mhz-1600K(CL=11, CWL=8)
 	                       DDR4-800Mhz-2400R(CL=12, CWL=11)
 
-	name: mv_ddr_twin_die
-	0 = twin-die combined
-	1 = single die(regular)
+	name: ddr_twin_die_index
+	0 = single die(regular)
+	1 = twin-die combined
 
 	name:   ddr_speedbin_index
 	value:


### PR DESCRIPTION
Align porting guide documentation for twin die ddr config option with
mv-ddr-marvell source code and existing DDR_TOPOLOGY_*.txt files.