### PR TITLE
wtmi: Fix calculation of UART divider

### DIFF
--- a/wtmi/sys_init/uart.c
+++ b/wtmi/sys_init/uart.c
@@ -39,15 +39,17 @@
 #include "uart.h"
 #include "delay.h"
 
-#define UART_CLOCK_FREQ		25804800
+#define DIV_ROUND_CLOSEST(x, divisor) (((x) + (divisor)/2) / (divisor))
 
 static void uart_set_baudrate(unsigned int baudrate)
 {
+	unsigned int clock = get_ref_clk() * 1000000;
+
 	/*
 	 * calculate divider.
 	 * baudrate = clock / 16 / divider
 	 */
-	writel((UART_CLOCK_FREQ / baudrate / 16), MVEBU_UART0_BAUD_REG);
+	writel(DIV_ROUND_CLOSEST(clock, baudrate * 16), MVEBU_UART0_BAUD_REG);
 	/* set Programmable Oversampling Stack to 0, UART defaults to 16X scheme */
 	writel(0, MVEBU_UART0_POSSR_REG);
 }


### PR DESCRIPTION
By default UART uses xtal as a base clock which has either 25 or 40 MHz.
Therefore current hardcoded UART frequency 25.8048 MHz is incorrect.

Calculation of UART divider should be rounded to the closest value after
division so final baudrate is the closest to the desired.

Fix these two issues by reading xtal clock via get_ref_clk() function and
round divider to the closest value.