### PR TITLE
Wtpdownloader: Fix opening tty device

### DIFF
--- a/wtptp/src/Wtpdownloader_Linux/src/UARTPortLinux.cpp
+++ b/wtptp/src/Wtpdownloader_Linux/src/UARTPortLinux.cpp
@@ -127,13 +127,12 @@ void CUARTPortLinux::OpenPort() throw (CWtpException)
 	UARTDeviceName ="/dev/ttyUSB" ;
 	UARTDeviceName.append(portNumber.str());
 	cout << endl << UARTDeviceName << endl;
-	uartLinuxFileDesc = open(UARTDeviceName.c_str(),O_RDWR|O_NOCTTY);
+	uartLinuxFileDesc = open(UARTDeviceName.c_str(),O_RDWR|O_NOCTTY|O_NONBLOCK);
 	if(uartLinuxFileDesc < 0)
 	{
 		cout << endl << " ERROR: Open UART driver failed:" << endl;
 		throw CWtpException(CWtpException::OPENUARTPORT,0,UARTDeviceName);
 	}
-	fcntl(uartLinuxFileDesc,F_SETFL,0);
 	memset(&options, 0, sizeof(options));
 	cfsetispeed(&options, B115200);
 	cfsetospeed(&options, B115200);
@@ -143,8 +142,9 @@ void CUARTPortLinux::OpenPort() throw (CWtpException)
 	options.c_cc[VMIN]   = 0;
 	options.c_cc[VTIME]  = 0;
 	options.c_cflag &= ~(CSIZE|PARENB);
-	options.c_cflag |= CS8;
+	options.c_cflag |= CS8|CLOCAL;
 	tcsetattr(uartLinuxFileDesc, TCSANOW, &options);
+	fcntl(uartLinuxFileDesc,F_SETFL,fcntl(uartLinuxFileDesc, F_GETFL) & ~O_NONBLOCK);
 }
 
 

--- a/wtptp/src/Wtpdownloader_Linux/src/UARTPortLinux.cpp
+++ b/wtptp/src/Wtpdownloader_Linux/src/UARTPortLinux.cpp
@@ -134,6 +134,7 @@ void CUARTPortLinux::OpenPort() throw (CWtpException)
 		throw CWtpException(CWtpException::OPENUARTPORT,0,UARTDeviceName);
 	}
 	memset(&options, 0, sizeof(options));
+	tcgetattr(uartLinuxFileDesc, &options);
 	cfsetispeed(&options, B115200);
 	cfsetospeed(&options, B115200);
 	options.c_iflag     &= ~(IGNBRK|BRKINT|PARMRK|ISTRIP|INLCR|IGNCR|ICRNL|IXON);

--- a/wtptp/src/Wtpdownloader_Linux/src/UARTPortLinux.cpp
+++ b/wtptp/src/Wtpdownloader_Linux/src/UARTPortLinux.cpp
@@ -142,7 +142,7 @@ void CUARTPortLinux::OpenPort() throw (CWtpException)
 	options.c_cc[VMIN]   = 0;
 	options.c_cc[VTIME]  = 0;
 	options.c_cflag &= ~(CSIZE|PARENB);
-	options.c_cflag |= CS8|CLOCAL;
+	options.c_cflag |= CS8|CLOCAL|CREAD;
 	tcsetattr(uartLinuxFileDesc, TCSANOW, &options);
 	fcntl(uartLinuxFileDesc,F_SETFL,fcntl(uartLinuxFileDesc, F_GETFL) & ~O_NONBLOCK);
 }


### PR DESCRIPTION
* Wtpdownloader: Fix stuck during opening UART tty device
* Wtpdownloader: Set CREAD tty cflag
* Wtpdownloader: Properly retrieve current tty options

This fixes issue #14