### PR TITLE
wtmi: Fix sending status code of cmd execution

### DIFF
--- a/wtmi/fuse/main.c
+++ b/wtmi/fuse/main.c
@@ -132,7 +132,7 @@ int main(int exception, char **dummy)
 {
 	u32			cmd, args[MAILBOX_MAX_ARGS];
 	u32			status, nargs;
-	enum mbox_status	mb_stat = MB_STAT_SUCCESS;
+	enum mbox_status	mb_stat;
 
 	if (exception != 0) {
 		exception_handler(exception);
@@ -154,6 +154,8 @@ int main(int exception, char **dummy)
 		if (status != NO_ERROR) {
 			nargs = 0;
 			mb_stat = args[0];
+		} else {
+			mb_stat = MB_STAT_SUCCESS;
 		}
 
 		/* Send the results back */


### PR DESCRIPTION
When cmd execution fails then mb_stat is set to error code which execution
returns. But mb_stat is not set when cmd execution success and reuse
previous mb_stat, which is error if previous status code was error.

It means that once cmd execution fails then all status code also for all
future cmd executions indicates error.

Fix this issue and explicitly set mb_stat to MB_STAT_SUCCESS after every
successful execution.

This fixes execution of efuse read commands received via mailbox API from
application CPU. With this change application CPU can finally receive
success response for efuse read commands with efuse data.