### PR TITLE
wtmi: Discard ELF symbols from firmware binary

### DIFF
--- a/wtmi/common/template.ld
+++ b/wtmi/common/template.ld
@@ -18,4 +18,12 @@ SECTIONS
   . = ALIGN(8);
   . = . + 0x1000; /* 4kB of stack memory */
   stack_top = .;
+
+  /DISCARD/ : { *(.interp*) }
+  /DISCARD/ : { *(.dynsym) }
+  /DISCARD/ : { *(.dynstr*) }
+  /DISCARD/ : { *(.dynamic*) }
+  /DISCARD/ : { *(.gnu*) }
+  /DISCARD/ : { *(.rel*) }
+  /DISCARD/ : { *(.ARM*) }
 }


### PR DESCRIPTION
WTMI firmware is raw binary generated by objcopy from compiled ELF binary.
Therefore ELF specific symbols (like name of linux ELF ld loader) are
unused. Discard all unused symbols which are not needed.

This change decrease size of sys_init.bin binary from 14036 bytes to just
8984 bytes and size of fuse.bin binary from 6380 bytes to just 1780 bytes.

Total size of wtmi.bin firmware is decreased from 20420 to just 10772 bytes.