### PR TITLE
wtmi: Remove usage of non-existant string.h file and memcpy() function

### DIFF
--- a/wtmi/sys_init/main.c
+++ b/wtmi/sys_init/main.c
@@ -37,7 +37,6 @@
 #include "clock.h"
 #include "avs.h"
 #include "ddr/ddrcore.h"
-#include <string.h>
 
 #if DEBUG
 #define ddr_debug printf
@@ -294,7 +293,7 @@ int sys_init_main(void)
 
 	/* Copy tuning result to reserved memory */
 	if (!ddr_para.warm_boot) {
-		memcpy(result_in_dram, &result_in_sram, sizeof(struct ddr_init_result));
+		*result_in_dram = result_in_sram;
 		*((u32 *)(DDR_TUNE_RESULT_MEM_BASE + sizeof(struct ddr_init_result))) =
 			do_checksum32((u32 *)&result_in_sram, sizeof(struct ddr_init_result));
 	}


### PR DESCRIPTION
A3700 sys_init firmware does not implement memcpy() function and does not
provide string.h header file. So do not use these two things as it cause
compile errors on Fedora build toolchain.

    main.c:40:10: fatal error: string.h: No such file or directory
       40 | #include <string.h>
          |          ^~~~~~~~~~
    main.c: In function ‘sys_init_main’:
    main.c:297:17: warning: implicit declaration of function ‘memcpy’ [-Wimplicit-function-declaration]
      297 |                 memcpy(result_in_dram, &result_in_sram, sizeof(struct ddr_init_result));
          |                 ^~~~~~
    main.c:297:17: warning: incompatible implicit declaration of built-in function ‘memcpy’ [-Wbuiltin-declaration-mismatch]
      297 |                 memcpy(result_in_dram, &result_in_sram, sizeof(struct ddr_init_result));
          |                 ^~~~~~
    compilation terminated.
    make[3]: *** [Makefile:161: main.o] Error 1
    make[2]: *** [Makefile:42: sys_init/build/sys_init.bin] Error 2
    make[1]: *** [Makefile:36: WTMI] Error 2

Instead of external memcpy() function for structure copying, use standard C
assignment operator '=' which works also for structures.

With Debian cross compile toolchain this patch does not change generated
assembler code. And fixes compilation with Fedora cross compile toolchain.