### PR TITLE
wtmi: Fix linker output sections

### DIFF
--- a/wtmi/common/template.ld
+++ b/wtmi/common/template.ld
@@ -6,14 +6,15 @@ SECTIONS
 {
   . = LOAD_ADDR;
   .ro : {
-    start.o (.text)
-    *(.text)
-    *(.rodata)
+    start.o (.text*)
+    *(.text*)
+    *(.rodata*)
   }
   .rw : {
-    *(.data)
+    *(.data*)
     *(.bss)
     *(COMMON)
+    *(.got*)
   }
   . = ALIGN(8);
   . = . + 0x1000; /* 4kB of stack memory */


### PR DESCRIPTION
More input sections are not correctly put into .ro and .rw output sections.
For example sys_init.elf contains following sections:

    Idx Name          Size      VMA       LMA       File off  Algn
      0 .ro           00001bac  1fff30c0  1fff30c0  000030c0  2**2
                      CONTENTS, ALLOC, LOAD, READONLY, CODE
      1 .rodata.str1.1 000002d6  1fff4c6c  1fff4c6c  00004c6c  2**0
                      CONTENTS, ALLOC, LOAD, READONLY, DATA
      2 .text.startup 0000005c  1fff4f44  1fff4f44  00004f44  2**2
                      CONTENTS, ALLOC, LOAD, READONLY, CODE
      3 .rw           000002a4  1fff4fa0  1fff4fa0  00004fa0  2**2
                      CONTENTS, ALLOC, LOAD, DATA
      4 .got          00000010  1fff5244  1fff5244  00005244  2**2
                      CONTENTS, ALLOC, LOAD, DATA
      5 .got.plt      0000000c  1fff5254  1fff5254  00005254  2**2
                      CONTENTS, ALLOC, LOAD, DATA
      6 .data.rel.ro.local 000001a0  1fff5260  1fff5260  00005260  2**2
                      CONTENTS, ALLOC, LOAD, DATA

This change fixes it, addis missing wildcards to correctly match all
.rodata*, .data*, .text* and .got* sections and after this change
sys_init.elf contains now only .ro and .rw:

    Idx Name          Size      VMA       LMA       File off  Algn
      0 .ro           00001ee8  1fff30c0  1fff30c0  000030c0  2**2
                      CONTENTS, ALLOC, LOAD, READONLY, CODE
      1 .rw           00000460  1fff4fa8  1fff4fa8  00004fa8  2**2
                      CONTENTS, ALLOC, LOAD, DATA