### PR TITLE
Modern compiler/linking support

### DIFF
--- a/wtmi/common/types.h
+++ b/wtmi/common/types.h
@@ -38,8 +38,6 @@ typedef short			s16;
 typedef char			s8;
 typedef char			byte;
 
-typedef int bool;
-
 #define	NULL			((void *)0)
 
 /* Errors */

--- a/wtmi/sys_init/ddr/ddrcore.h
+++ b/wtmi/sys_init/ddr/ddrcore.h
@@ -35,6 +35,8 @@
 #ifndef __DDRCORE_H_
 #define __DDRCORE_H_
 
+#include <stdbool.h>
+
 #define MAX_CS_NUM		2
 #define MAX_BANK_GROUP_NUM	4
 #define MAX_BANK_NUM	8

--- a/wtmi/sys_init/main.c
+++ b/wtmi/sys_init/main.c
@@ -344,9 +344,11 @@ int main(int exception, char **dummy)
 	* to SRAM start address 0x1fff0000. CM3 executing start address is
 	* sys_init.bin start address; after sys_init finishes the
 	* initialization work, PC address will jump back to WTMI runing image
-	* start address 0x1fff0000.
+	* start address 0x1fff0000. We tell the linker that this is a thumb
+	* address by setting the least significant bit resulting in 0x1fff0001.
 	*/
-	__asm__ volatile("bl 0x1fff0000\n");
+	void (*const start)(void) = (void (*)(void))0x1fff0001;
+	start();
 
 	return NO_ERROR;
 }

--- a/wtmi/sys_init/start.S
+++ b/wtmi/sys_init/start.S
@@ -131,5 +131,6 @@ external_interrupt:
 	ldr	r1, =main
 	bx	r1
 
+.section .note.GNU-stack,"",%progbits
 
 .end


### PR DESCRIPTION
There are three changes here. One addresses the failure to build with `ld` shipped with `binutils` 2.44 and newer as noted [here](https://github.com/MarvellEmbeddedProcessors/A3700-utils-marvell/issues/35). One addresses a failure to build with the C23 standard which is the default with `gcc` 15. The last addresses a linker warning.